### PR TITLE
flask-wtf 1.2.1

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,4 @@
+channels:
+  - https://staging.continuum.io/prefect/fs/werkzeug-feedstock/pr10/32826d1
+  - https://staging.continuum.io/prefect/fs/itsdangerous-feedstock/pr4/6569ec4
+  - https://staging.continuum.io/prefect/fs/flask-feedstock/pr11/fc6007f

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,4 +1,0 @@
-channels:
-  - https://staging.continuum.io/prefect/fs/werkzeug-feedstock/pr10/32826d1
-  - https://staging.continuum.io/prefect/fs/itsdangerous-feedstock/pr4/6569ec4
-  - https://staging.continuum.io/prefect/fs/flask-feedstock/pr11/fc6007f

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,33 +1,29 @@
 {% set name = "Flask-WTF" %}
-{% set version = "1.0.1" %}
+{% set version = "1.2.1" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 34fe5c6fee0f69b50e30f81a3b7ea16aa1492a771fe9ad0974d164610c09a6c9
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/flask_wtf-{{ version }}.tar.gz
+  sha256: 8bb269eb9bb46b87e7c8233d7e7debdf1f8b74bf90cc1789988c29b37a97b695
 
 build:
-  skip: True  # [py<36]
+  skip: True  # [py<38]
   number: 0
-  script: "{{ PYTHON }} -m pip install . --no-deps -vv"
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vv
 
 requirements:
   host:
     - pip
-    - python 
-    - wheel
-    - setuptools
-
+    - python
+    - hatchling
   run:
-    - python 
+    - python
     - flask
-    - werkzeug
     - wtforms
     - itsdangerous
-    - email-validator
 
 test:
   imports:
@@ -39,16 +35,16 @@ test:
     - pip check
 
 about:
-  home: https://github.com/lepture/flask-wtf
+  home: https://github.com/wtforms/flask-wtf
   license: BSD-3-Clause
   license_family: BSD
   license_file: LICENSE.rst
-  summary: 'Simple integration of Flask and WTForms'
+  summary: Simple integration of Flask and WTForms
   description: |
     Flask-WTF is a simple integration of Flask and WTForms including CSRF,
     file upload and reCAPTCHA.
-  dev_url: https://github.com/lepture/flask-wtf
-  doc_url: https://github.com/wtforms/flask-wtf/tree/v{{ version }}/docs
+  dev_url: https://github.com/wtforms/flask-wtf
+  doc_url: https://pythonhosted.org/Flask-WTF/
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
**Destination channel:** main

### Links

- [PKG-4830](https://anaconda.atlassian.net/browse/PKG-4830)
- release-notes: https://github.com/wtforms/flask-wtf/releases
- release-diff: https://github.com/wtforms/flask-wtf/compare/v1.0.1...v1.2.1
- license: https://github.com/wtforms/flask-wtf/blob/main/LICENSE.rst
- requirements-tagged:
- https://github.com/wtforms/flask-wtf/blob/v1.2.1/pyproject.toml
- https://github.com/wtforms/flask-wtf/tree/v1.2.1/requirements


### Explanation of changes:

- Clean up the recipe by conda-lint
- Update host and run dependencies
- Update home, dev & doc urls

### Notes:

- Updating to make it compatible with `flask 3.0.3` https://github.com/AnacondaRecipes/flask-feedstock/pull/11

[PKG-4830]: https://anaconda.atlassian.net/browse/PKG-4830?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ